### PR TITLE
abort camera transition if dialogue ends

### DIFF
--- a/Assets/Scripts/InteractSystem/PlayerInteract.cs
+++ b/Assets/Scripts/InteractSystem/PlayerInteract.cs
@@ -95,6 +95,7 @@ public class PlayerInteract : MonoBehaviour, IEventHandler<DialogueEndedEvent>
 
     public void Handle(DialogueEndedEvent eventArgs)
     {
+        isTransitioning = false;
         PlayerCamera.transform.position = resetPosition;
         PlayerCamera.transform.rotation = resetRotation;
     }


### PR DESCRIPTION
https://trello.com/c/IyHj0u6z

A small fix that should resolve the weird camera movements if a dialogue is closed early.