### PR TITLE
do not assign new position to defined open pos.

### DIFF
--- a/Assets/Door system/Sliding Door/SlidingDoorController.cs
+++ b/Assets/Door system/Sliding Door/SlidingDoorController.cs
@@ -20,7 +20,8 @@ public class SlidingDoorController : MonoBehaviour
     {
         closedPosition = door.localPosition;
         // Set the open position (you can adjust this based on how far you want the door to slide)
-        openPosition = closedPosition - new Vector3(1f, 0, 0); // Slides 3 units to the right
+        if (openPosition == null || openPosition == Vector3.zero)
+            openPosition = closedPosition - new Vector3(1f, 0, 0); // Slides 3 units to the right
     }
 
     public void activateDoor()


### PR DESCRIPTION
### Door script only x-axis no longer

To this point, the open position is always overwritten by the script, and thus only allowed slides along the x-axis. Through this pr, we check if there is an assigned open-position, if there is, we use that instead. Not the best solution, but it will work for now... 